### PR TITLE
Tmp fixing the value of the webhook to avoid OOM

### DIFF
--- a/cmd/eventing-operator/kodata/knative-eventing/1-eventing.yaml
+++ b/cmd/eventing-operator/kodata/knative-eventing/1-eventing.yaml
@@ -683,7 +683,7 @@ spec:
           limits:
             # taken from serving.
             cpu: 200m
-            memory: 200Mi
+            memory: 1024Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
this is a tmp fix, see https://github.com/openshift-knative/eventing-operator/pull/14

With the 0.15+ release of the operator, we can properly use the `resources` field to override 