### PR TITLE
Updating the operator defaults for our offering

### DIFF
--- a/pkg/reconciler/knativeeventing/common/defaultbroker.go
+++ b/pkg/reconciler/knativeeventing/common/defaultbroker.go
@@ -51,7 +51,7 @@ func DefaultBrokerConfigMapTransform(instance *eventingv1alpha1.KnativeEventing,
 
 			defaultBrokerClass := instance.Spec.DefaultBrokerClass
 			if defaultBrokerClass == "" {
-				defaultBrokerClass = eventing.ChannelBrokerClassValue
+				defaultBrokerClass = eventing.MTChannelBrokerClassValue
 			}
 			defaults.ClusterDefault.BrokerClass = defaultBrokerClass
 

--- a/pkg/reconciler/knativeeventing/common/defaultbroker_test.go
+++ b/pkg/reconciler/knativeeventing/common/defaultbroker_test.go
@@ -54,7 +54,7 @@ func createupdateDefaultBrokerTests(t *testing.T) []updateDefaultBrokerTest {
 			defaultBrokerClass: "",
 			expected: makeConfigMap(t, "config-br-defaults", map[string]map[string]string{
 				"clusterDefault": {
-					"brokerClass": "ChannelBasedBroker",
+					"brokerClass": "MTChannelBasedBroker",
 					"apiVersion":  "v1",
 					"kind":        "ConfigMap",
 					"name":        "config-br-default-channel",


### PR DESCRIPTION
For our 0.14 delivery, we push forward on setting the easier to use MTChannelBroker for default

