### PR TITLE
[SRVKS-575] Abort reconcilation on finalizer patch errors.

### DIFF
--- a/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing/reconciler.go
+++ b/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing/reconciler.go
@@ -21,6 +21,7 @@ package knativeeventing
 import (
 	context "context"
 	"encoding/json"
+	fmt "fmt"
 	"reflect"
 
 	zap "go.uber.org/zap"
@@ -154,7 +155,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
 
 		// Reconcile this copy of the resource and then write back any status
@@ -168,7 +169,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
-			logger.Warnw("Failed to clear finalizers", zap.Error(err))
+			return fmt.Errorf("failed to clear finalizers: %w", err)
 		}
 	}
 

--- a/pkg/client/injection/reconciler/operator/v1alpha1/knativeserving/reconciler.go
+++ b/pkg/client/injection/reconciler/operator/v1alpha1/knativeserving/reconciler.go
@@ -21,6 +21,7 @@ package knativeserving
 import (
 	context "context"
 	"encoding/json"
+	fmt "fmt"
 	"reflect"
 
 	zap "go.uber.org/zap"
@@ -154,7 +155,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			return fmt.Errorf("failed to set finalizers: %w", err)
 		}
 
 		// Reconcile this copy of the resource and then write back any status
@@ -168,7 +169,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
-			logger.Warnw("Failed to clear finalizers", zap.Error(err))
+			return fmt.Errorf("failed to clear finalizers: %w", err)
 		}
 	}
 

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -145,6 +145,7 @@ func (g *reconcilerReconcilerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "context",
 			Name:    "Context",
 		}),
+		"fmtErrorf": c.Universe.Package("fmt").Function("Errorf"),
 	}
 
 	sw.Do(reconcilerInterfaceFactory, m)
@@ -295,7 +296,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if resource, err = r.setFinalizerIfFinalizer(ctx, resource); err != nil {
-			logger.Warnw("Failed to set finalizers", zap.Error(err))
+			return {{.fmtErrorf|raw}}("failed to set finalizers: %w", err)
 		}
 
 		// Reconcile this copy of the resource and then write back any status
@@ -309,7 +310,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
 		if resource, err = r.clearFinalizer(ctx, resource, reconcileEvent); err != nil {
-			logger.Warnw("Failed to clear finalizers", zap.Error(err))
+			return {{.fmtErrorf|raw}}("failed to clear finalizers: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**Note:** This has been sent upstream in https://github.com/knative/pkg/pull/1423. I cut some corners here to be able to quickly fix this.

---

This aborts reconcilation if finalizers could not be patched correctly with an error and thus it retries.

We shouldn't start a reconcilation if we haven't been able to correctly add the finalizer first. Otherwise we could get into a weird spot where the resources are created before the finalizer and in a very degenerate case the finalizer wouldn't even be executed. Also, the current code has a bug where if the patch fails the resource coming back from the patch (essentially an empty object) is passed into ReconcileKind, causing headaches.

The same imo goes for removing a finalizer. Failing to remove a finalizer blocks the resource forever, thus we should retry if that happens too.