### PR TITLE
[SRVKS-452] Bump webhook memory limit to 1G.

### DIFF
--- a/cmd/serving-operator/kodata/knative-serving/2-serving-core.yaml
+++ b/cmd/serving-operator/kodata/knative-serving/2-serving-core.yaml
@@ -1384,7 +1384,7 @@ spec:
             memory: 20Mi
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 1024Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
This is just a stopgap if we want to ship the rc1 release before doing the right thing.

/hold

Unhold if we want to take a shortcut.
