### PR TITLE
Overriding the default for our own distribution

### DIFF
--- a/cmd/eventing-operator/kodata/knative-eventing/1-eventing.yaml
+++ b/cmd/eventing-operator/kodata/knative-eventing/1-eventing.yaml
@@ -703,7 +703,7 @@ spec:
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE
-          value: "exclusion"
+          value: "inclusion"
         securityContext:
           allowPrivilegeEscalation: false
         ports:


### PR DESCRIPTION
We do want to have the value of our shipped eventing to be `inclusion` for the `SINK_BINDING_SELECTION_MODE`