### PR TITLE
SRVKE-474: adding ttlSecondsAfterFinished to the job

### DIFF
--- a/cmd/eventing-operator/kodata/knative-eventing/2-upgrade-to-v0.14.2.yaml
+++ b/cmd/eventing-operator/kodata/knative-eventing/2-upgrade-to-v0.14.2.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.14.2"
 spec:
+  ttlSecondsAfterFinished: 600
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Do we really need to do this for 1.8.0 (release-0.14 branch) ? 

I think this is only valid, if we enable the feature flag

see SRVKE-474 fore details