### PR TITLE
SRVKE-474: adding ttlSecondsAfterFinished to the job

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.15.2/2-upgrade-to-v0.15.2.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.2/2-upgrade-to-v0.15.2.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.15.2"
 spec:
+  ttlSecondsAfterFinished: 600
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

I think this is only valid, if we enable the feature flag

see SRVKE-474 fore details