### PR TITLE
[0.16] Do not ship GCR.IO images

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.16.0/1-eventing-pre-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.0/1-eventing-pre-install-jobs.yaml
@@ -279,7 +279,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:9590c747c81763027b8b8df12a4f66787ff693570f0a8b482b7a301b328157c0
+        image: TO_BE_REPLACED
         args:
         - "brokers.eventing.knative.dev"
         - "pingsources.sources.knative.dev"

--- a/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
@@ -605,7 +605,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:069ad618f481684a4ebb6d0bbc464b1a428283e45fed317775ea62f4ab644be9
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -623,12 +623,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:89500ee97a2e4ab93e04861e0665a807649bb123e59ca04a2bb1faf94d4357c0
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:668176e247f37c0557b8804dddda0b5166aa77dbad1b8c769eedeffc24133133
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:19e329d070193aad98327e866905932f89eea54e92ad86f87c8ce87ccdf8e150
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -675,7 +675,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:5ec94b03015378e8309e94cb5415f61e1353748d7a46015578d70763835adb7e
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.
@@ -2878,7 +2878,7 @@ spec:
       containers:
       - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/channel_broker@sha256:7d3ae9a7139a846490869e58d9f4ddbe31b8a60df306c3636962609fbcca523d
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -2896,11 +2896,11 @@ spec:
           value: knative.dev/eventing
         - # Broker
           name: BROKER_INGRESS_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:a7a9dba94024ba961604f08be1bc49eddb40941dee4f291ed609149d899e7afa
+          value: TO_BE_REPLACED
         - name: BROKER_INGRESS_SERVICE_ACCOUNT
           value: eventing-broker-ingress
         - name: BROKER_FILTER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:fa50a25fd2db5ab09cc604d2b3d4ad36da3687882352c68ca11cb273e65111f7
+          value: TO_BE_REPLACED
         - name: BROKER_FILTER_SERVICE_ACCOUNT
           value: eventing-broker-filter
         - name: BROKER_IMAGE_PULL_SECRET_NAME
@@ -3198,7 +3198,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:3b85d745bba2f32f2e60ddca2781969198d8c82434e18706c040b06884a42f8d
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3270,7 +3270,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:3b85d745bba2f32f2e60ddca2781969198d8c82434e18706c040b06884a42f8d
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3381,7 +3381,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:b856d2e4184f5cd5fe2716a89d39a055b776f0e717206b5f612beaa9c93fd60e
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3453,7 +3453,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:b856d2e4184f5cd5fe2716a89d39a055b776f0e717206b5f612beaa9c93fd60e
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3562,7 +3562,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:31ba50ad423be0cbece62cdb01aa1f75958c56503d8b7cde0b4b1e91ea357243
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -4153,7 +4153,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:5bae1865c588b21ce04562616ea12a8b6eef9a380db2ee87d217171c0143c4cc
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -4166,7 +4166,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:d271dc40ef6d1161b28b0b61dfa71583e89ad6c8847adeede1a8504fb8f5b908
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -4211,7 +4211,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:d271dc40ef6d1161b28b0b61dfa71583e89ad6c8847adeede1a8504fb8f5b908
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.16.0/3-eventing-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.0/3-eventing-post-install-jobs.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: brokers
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/v0.16/broker-cleanup@sha256:9decf1a44a1f7aa654517be6caaa5a1db2d38285ece4e56b3148851086b65480
+        image: TO_BE_REPLACED
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/cmd/operator/kodata/knative-eventing/0.16.1/1-eventing-pre-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/1-eventing-pre-install-jobs.yaml
@@ -281,7 +281,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:7da227ccb60c0a2a19565d88d185ebf2551854c765d539967e84e6166a51d492
+        image: TO_BE_REPLACED
         args:
         - "brokers.eventing.knative.dev"
         - "pingsources.sources.knative.dev"

--- a/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
@@ -605,7 +605,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:7fa646456d0a867341b283d59078703fadb4480432d99276a75868997c69db19
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -623,12 +623,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:d1c2b997691805f312e1060fda4369c2314b2d682349c81cfc36ab4b6b9c1303
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:18a322a7e78f97144b3520262d7680293a99b97918bc212c9b93b6c9801b3c11
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:55c28fe67479c66f5ddd641a0dcf450b85869b33eadb0ff6743994e8382f5373
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -675,7 +675,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:7d839aff3c564981b534922f5a20ab89ccca58533b56b4c6d0f5246eee4a7497
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.
@@ -2877,7 +2877,7 @@ spec:
       containers:
       - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/channel_broker@sha256:7d3ae9a7139a846490869e58d9f4ddbe31b8a60df306c3636962609fbcca523d
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -2895,11 +2895,11 @@ spec:
           value: knative.dev/eventing
         - # Broker
           name: BROKER_INGRESS_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:a7a9dba94024ba961604f08be1bc49eddb40941dee4f291ed609149d899e7afa
+          value: TO_BE_REPLACED
         - name: BROKER_INGRESS_SERVICE_ACCOUNT
           value: eventing-broker-ingress
         - name: BROKER_FILTER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:fa50a25fd2db5ab09cc604d2b3d4ad36da3687882352c68ca11cb273e65111f7
+          value: TO_BE_REPLACED
         - name: BROKER_FILTER_SERVICE_ACCOUNT
           value: eventing-broker-filter
         - name: BROKER_IMAGE_PULL_SECRET_NAME
@@ -3197,7 +3197,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:d2422d39e463c99cd21af3c51ee2947613e2418f88a8403ed4af52d9864e5fa1
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3269,7 +3269,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:d2422d39e463c99cd21af3c51ee2947613e2418f88a8403ed4af52d9864e5fa1
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3380,7 +3380,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:cb240de03ef3a63ce1a67d56c4ac6f06a50dfa90f2f0d50416366770c2ffcd2d
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3452,7 +3452,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:cb240de03ef3a63ce1a67d56c4ac6f06a50dfa90f2f0d50416366770c2ffcd2d
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3561,7 +3561,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:57e85e39f38f20fd96ecef7a326797e074a5bc4fc4a60f5086b9dab771b9eebf
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -4152,7 +4152,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:3d63a5cf636128837c2f028768271c1fd2359ba353325b64d0d19953cb69ea1f
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -4165,7 +4165,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:2f3cbaf9ab610de8e937ecd0801c67b5f51f51f8480bd4291a823203bea64c1e
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -4210,7 +4210,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:2f3cbaf9ab610de8e937ecd0801c67b5f51f51f8480bd4291a823203bea64c1e
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.16.1/3-eventing-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/3-eventing-post-install-jobs.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: brokers
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/v0.16/broker-cleanup@sha256:b7915f9ff75e90b728c2ccc85417d593ea2025609585c980a1bd0b0fdeeff98d
+        image: TO_BE_REPLACED
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
@@ -131,7 +131,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:ab38418f2e13dfc21d48c64af0589f4eae5c40fc34a5e02f48b24b7156391d22
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -457,7 +457,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:ab38418f2e13dfc21d48c64af0589f4eae5c40fc34a5e02f48b24b7156391d22
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -1188,7 +1188,7 @@ spec:
       - name: activator
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:e743f3309af4b79fe6af377b7bd5ae059a422c0db3d6aed2ae48d79b8aa59edf
+        image: TO_BE_REPLACED
         # The numbers are based on performance test results from
         # https://github.com/knative/serving/issues/1625#issuecomment-511930023
         resources:
@@ -1316,7 +1316,7 @@ spec:
       - name: autoscaler
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:2ef460356b17481bc467fc7c35da581707dc490b1f32083457d6d4faed9ef300
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -1415,7 +1415,7 @@ spec:
       - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:30ce73388ae53e44edb52c1ef3b73b755e47004a90781fa9e0257cd021b20327
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -1504,7 +1504,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:f16c0e022203f70a4228fba7d4cd951739ee43b491af9dbc569f233c9588e92a
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-serving/0.16.0/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/3-serving-hpa.yaml
@@ -37,7 +37,7 @@ spec:
       - name: autoscaler-hpa
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:e2a6d606d581cb3c34513617bd898e00ea8794f59481848901717964845d1603
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m

--- a/cmd/operator/kodata/knative-serving/0.16.0/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/4-net-istio.yaml
@@ -309,7 +309,7 @@ spec:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:d1a2143c0e7b6d5891426ca12e1de940c08caeafafe6ca4f23a560d03a0854c5
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -382,7 +382,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:439b6d1669c8d010d4c54c37578dd6165e1f181d3595aa9b2d628f76a906f904
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 20m

--- a/cmd/operator/kodata/knative-serving/0.16.0/5-serving-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/5-serving-post-install-jobs.yaml
@@ -39,7 +39,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:677a46ee83412a3b134262f386e80ff2a1cea550378158dfbb990ba828b72b42
+        image: TO_BE_REPLACED
         args:
         - "services.serving.knative.dev"
         - "configurations.serving.knative.dev"


### PR DESCRIPTION
Relates to #13 and https://issues.redhat.com/browse/SRVKS-576

"Fixing" this for the 0.16 branch (aka 1.10 Serverless)

/assign @markusthoemmes 