### PR TITLE
[0.17] Removing GCR.io references

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.17.0/1-eventing-pre-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/1-eventing-pre-install-jobs.yaml
@@ -281,7 +281,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:d3b40611a0a56970b834b2e9ca86503337973bc7acf0a92114afd74630b8ebe3
+        image: TO_BE_REPLACED
         args:
         - "brokers.eventing.knative.dev"
         - "pingsources.sources.knative.dev"

--- a/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
@@ -603,7 +603,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:3df49b95f5dc475040898131e540e366d8d1d3c7053cfcbe41a51f92d1a858d0
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -621,12 +621,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:752c605f4ba0d5e3e011c994dbe3c0e1f5ba3d13950dc302ab861bf933c142e3
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:4c2c2f951f0253cf215cfc69956a12d7e7cecccc56c97f0dbebb735d96ca6360
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:ceefab626aeb74523bbe1f5fa11e01377b1937af1d3575ed026e0543fc787212
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -683,7 +683,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:e0bba359e5bd05c074f3f1141d6fb72911d5629a61fe974e444e86b4b66e668c
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.

--- a/cmd/operator/kodata/knative-eventing/0.17.0/4-in-memory-channel.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/4-in-memory-channel.yaml
@@ -506,7 +506,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:7649888fca4e4ab693c6f0ad51296065cf6682cbafe7455efedab3b80bb00c4a
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -519,7 +519,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:8e8763fd783a213f1836b1c70bbf7d6803ba57b6bc2021c2b1d78afb321b621b
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -564,7 +564,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:8e8763fd783a213f1836b1c70bbf7d6803ba57b6bc2021c2b1d78afb321b621b
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.17.0/5-mt-channel-broker.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/5-mt-channel-broker.yaml
@@ -285,7 +285,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:c3fcf096439ef7cd438b97f44e0318ca6d94b73c47953de768c92de584dbcd3c
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -393,7 +393,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:1af3d594ca277ae16c94279506c1786851b1e4c504539fa2840f777c61cb8876
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -512,7 +512,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:214355f1087b88ddcec0220059313fa9244ea3696d5d90c23ea3bd296b5e18b4
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-eventing/0.17.0/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/6-eventing-sugar-controller.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: eventing-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:04f4c49777e68a97124cf980cebab77b584956d2fac2fe1a9df4e5c82c3284eb
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.17.0/7-eventing-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/7-eventing-post-install-jobs.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: pingsource
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/v0.17/pingsource-cleanup@sha256:c6f5e5d7d834917f56bed9a4cdfbe69fc99be6ab33223e59e8294c12d9f2c039
+        image: TO_BE_REPLACED
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
@@ -603,7 +603,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:0185928c7d2b94b4892fa920a3243c8465b41cc17913a6c9f2c85b98ed15b3bc
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -621,12 +621,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:71c81707d7af93d014d89eca6289a5b103180276c092e9c68d2a2494d4e11e57
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:1a3237ec29f579483ff741906a8e619df8e273c1bfece0b30bc2f7f0fbe77294
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:e2ee4ad47d45fb9fd03692d454bf1ad0175260c772115df2dd997cbefbdf2043
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -683,7 +683,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:70bffdff69d2a3ea3d67063d61555ed8419cdd8394f9819c2351741ec964a949
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.

--- a/cmd/operator/kodata/knative-eventing/0.17.1/3-in-memory-channel.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/3-in-memory-channel.yaml
@@ -506,7 +506,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:28d8656b769c4b222e31d5bb200518c1ec55a4a7114fa711b36c5e4dc90826fd
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -519,7 +519,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:2a86428a09783a02e6c7b28196bc5810ddaa2f5178e74e9cd655eaf99dcbe716
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -564,7 +564,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:2a86428a09783a02e6c7b28196bc5810ddaa2f5178e74e9cd655eaf99dcbe716
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.17.1/4-mt-channel-broker.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/4-mt-channel-broker.yaml
@@ -285,7 +285,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:dbfb7186044210df8875895d419888db76ccd76fa581af8a633f37ba56b6293b
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -393,7 +393,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:7dcb5360b9ae0b15c167f95cd412de1d13bc15c51ced565352c62c4e50a9c4b1
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -512,7 +512,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:2b439ec29b6ad619a0a08d4faa9d9cb7432c9434253f3d1e1df9aade0f30ee9e
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-eventing/0.17.1/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/5-eventing-sugar-controller.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: eventing-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:c9d2e6fda67678eec27b891ecc604a51284f09e7bbdbd703634a9adb875d79d1
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.17.1/6-eventing-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/6-eventing-post-install-jobs.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: pingsource
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/v0.17/pingsource-cleanup@sha256:c5d1dfa52dd12defaa29b596f85bc36faabd9ba407dffa69b18f5b984418b1fd
+        image: TO_BE_REPLACED
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
@@ -603,7 +603,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:c067e106fb96a3341f85b372b76e78a6a67fad96e153822726ab5e95f8e4f70d
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -621,12 +621,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:e2178e0ae7442954001e069c823af98fae577cdad978ed01151ee691931e1eb1
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:3b5694e2ded90fe3c70629c15cc2ede333228e21c88e8477c8ef09d07523f474
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:e23ce48b9931ca012b93794aaf7805cfe017e1fae1c69da2287e81e40aff82be
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -683,7 +683,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:8581a89a9640e0cf01df678a788754adea12a3fb1657c69d130da2240b70b398
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.

--- a/cmd/operator/kodata/knative-eventing/0.17.2/3-in-memory-channel.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/3-in-memory-channel.yaml
@@ -506,7 +506,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:c4a2fe9437691321c311b1419c07775ba659d8804c6a6aa2700e8f8c2e3fad49
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -519,7 +519,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:47ccfcf354a6500fb18763170ebf5496e55db01edd023458887f4bcd2f54df6e
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -564,7 +564,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:47ccfcf354a6500fb18763170ebf5496e55db01edd023458887f4bcd2f54df6e
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.17.2/4-mt-channel-broker.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/4-mt-channel-broker.yaml
@@ -285,7 +285,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:240e981ab14feb183af126addb78de8fb9480d8b9f5b91a04616a7b264f86fd9
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -393,7 +393,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:a38342850018735caefa37b26b97ca937496cc0f770dd73d00026300a0d4ef5c
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -512,7 +512,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:e9f663f4ed64995c1fce4b87db35c8bf58bc5de37657b7cff2a5210f873e18c0
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-eventing/0.17.2/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/5-eventing-sugar-controller.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: eventing-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:4f2678d1a9c791e43010c35bb02283f8432b85326875f1e5fea5b8d380829e9d
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.17.2/6-eventing-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/6-eventing-post-install-jobs.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: pingsource
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/v0.17/pingsource-cleanup@sha256:8ee9f443cfa7f32ca32bede95521680f0679358676403640dcc12dd02689d25d
+        image: TO_BE_REPLACED
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
@@ -131,7 +131,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:bba041b926e31e9d5da2cb799001b31fce4c519037334db3751eb5f69d0f227f
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -475,7 +475,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:bba041b926e31e9d5da2cb799001b31fce4c519037334db3751eb5f69d0f227f
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -1311,7 +1311,7 @@ spec:
       - name: activator
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:18aadbb4796d7b6316ae971be5233dac28cd794c517e220d127aa9e21d91df42
+        image: TO_BE_REPLACED
         # The numbers are based on performance test results from
         # https://github.com/knative/serving/issues/1625#issuecomment-511930023
         resources:
@@ -1449,7 +1449,7 @@ spec:
       - name: autoscaler
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:0af019e5d0b936468f85f5ca3c658b4913e5ac08734cf377bbbd8ba93eaa9db0
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -1558,7 +1558,7 @@ spec:
       - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:5f118d434661a895096c69c036de20c962aee445e339cc9e1b1bf806895d6fa2
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -1657,7 +1657,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:d36f460aea55b93cce222bcee129776dee356e6499db73f232bfdf482ce28f66
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-serving/0.17.0/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/3-serving-hpa.yaml
@@ -47,7 +47,7 @@ spec:
       - name: autoscaler-hpa
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:3e1ba3f92155360391fe3775a3b4b099cd11de6f1f650a8d211fe01c396f7b23
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m

--- a/cmd/operator/kodata/knative-serving/0.17.0/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/4-net-istio.yaml
@@ -309,7 +309,7 @@ spec:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:6da903d755509b5d9618491177ff5efc7a39e998d33c1383db461bc99a5e4392
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -382,7 +382,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:3e9eacff55f07aacfd46ce28c472ee8c8999c284b3347d3c46eeb67347b2ea67
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 20m

--- a/cmd/operator/kodata/knative-serving/0.17.0/5-serving-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/5-serving-post-install-jobs.yaml
@@ -39,7 +39,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:e1ce411416ea2a2fe1b27554bf06ad82bdbf0eeaf3cef37072d2306593d4d6f3
+        image: TO_BE_REPLACED
         args:
         - "services.serving.knative.dev"
         - "configurations.serving.knative.dev"

--- a/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
@@ -131,7 +131,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:49ba69fe53f114fce2014d4fa8e6ceb8437ca22808f547cd68fe7555580ccc1e
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -475,7 +475,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:49ba69fe53f114fce2014d4fa8e6ceb8437ca22808f547cd68fe7555580ccc1e
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -1311,7 +1311,7 @@ spec:
       - name: activator
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:188eb96379053e767f67d2bdf90a2620752f1d2e376712b00a4dee87618b0149
+        image: TO_BE_REPLACED
         # The numbers are based on performance test results from
         # https://github.com/knative/serving/issues/1625#issuecomment-511930023
         resources:
@@ -1449,7 +1449,7 @@ spec:
       - name: autoscaler
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:1d0ed83bb2f28cc6e36cca289a759c3fc8e5c51749ed19610f83a9a555e5fb76
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -1558,7 +1558,7 @@ spec:
       - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:5873e5805c623b64691d54b44156614c12a3f42c79873b74140cd8f2b31bc60c
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -1657,7 +1657,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:fbdd2e3cbb76c812d0788ab037b18afe6caa8b7b8aaca00335cf7f62ea0b1211
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-serving/0.17.1/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/3-serving-hpa.yaml
@@ -47,7 +47,7 @@ spec:
       - name: autoscaler-hpa
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:acdeb06b467c1c7007f2eeb1561626202434a17d9d5fe352332889184e0a4a84
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m

--- a/cmd/operator/kodata/knative-serving/0.17.1/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/4-net-istio.yaml
@@ -309,7 +309,7 @@ spec:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:6da903d755509b5d9618491177ff5efc7a39e998d33c1383db461bc99a5e4392
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -382,7 +382,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:3e9eacff55f07aacfd46ce28c472ee8c8999c284b3347d3c46eeb67347b2ea67
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 20m

--- a/cmd/operator/kodata/knative-serving/0.17.1/5-serving-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/5-serving-post-install-jobs.yaml
@@ -39,7 +39,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:28a54abc69278e4b00266ca44f7fff6499d2d9e3dfbbf2a5fe3b5cb18cf6404b
+        image: TO_BE_REPLACED
         args:
         - "services.serving.knative.dev"
         - "configurations.serving.knative.dev"


### PR DESCRIPTION
Relates to #13 and https://issues.redhat.com/browse/SRVKS-576

"Fixing" this for the 0.17 branch (aka 1.11 Serverless)