### PR TITLE
[0.15] Removing GCR.io references

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
@@ -599,7 +599,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:ce0b0cc472fbfe9c6bc0117abb7f6811d9f792a49e2bf6a94d1ed8a180ce48a2
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -617,12 +617,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:035d1b146213227d45d7660b8e4efe2ea0fec3ef547e86b0cac4a524dfc4914c
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:a6aa9587ea991f0f9dfbca7f90146a0b62a0926dcc8535aa345f038b38266f49
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:0e4363965b8eb8066ac6fc33899f7258a283a82ca9df8d9cdae308b9df3cc780
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -669,7 +669,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:001394ef61762a1605a0a10e49c4100b5db0a70de9a4f419455ecccdc988e569
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.
@@ -3002,7 +3002,7 @@ spec:
       containers:
       - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/channel_broker@sha256:7d3ae9a7139a846490869e58d9f4ddbe31b8a60df306c3636962609fbcca523d
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -3020,11 +3020,11 @@ spec:
           value: knative.dev/eventing
         - # Broker
           name: BROKER_INGRESS_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:a7a9dba94024ba961604f08be1bc49eddb40941dee4f291ed609149d899e7afa
+          value: TO_BE_REPLACED
         - name: BROKER_INGRESS_SERVICE_ACCOUNT
           value: eventing-broker-ingress
         - name: BROKER_FILTER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:fa50a25fd2db5ab09cc604d2b3d4ad36da3687882352c68ca11cb273e65111f7
+          value: TO_BE_REPLACED
         - name: BROKER_FILTER_SERVICE_ACCOUNT
           value: eventing-broker-filter
         - name: BROKER_IMAGE_PULL_SECRET_NAME
@@ -3319,7 +3319,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:ef6e603150dd227a6dcf47bb751fb1f1fc2cc089309f087aafc5da2962accc01
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3427,7 +3427,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:27bb6d1ea42994900608129364ec018489c27371bccf4ab32d28085e7f8ede4c
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3536,7 +3536,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:091e352d8039198d934a9555f4655b905ebffeb2d1a6728712804bbfc9eaf10e
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -4115,7 +4115,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:d4180ef0d7e7ed2ef3d4cfc5ef3cc6a7ea3dec954aa87a374645db69d2c83bd8
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -4128,7 +4128,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:92671a182e13925be24b6512076e703a4fb7b81edcc030f5f911b710b567f653
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -4172,7 +4172,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:92671a182e13925be24b6512076e703a4fb7b81edcc030f5f911b710b567f653
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.15.0/2-upgrade-to-v0.15.0.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/2-upgrade-to-v0.15.0.yaml
@@ -15,6 +15,6 @@ spec:
       restartPolicy: Never
       containers:
       - name: upgrade-brokers
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/upgrade/v0.15.0@sha256:1bfd9ebc1d5420ec734fec79c09d11d806c63b71d838f249973e4bd50773cb2b
+        image: TO_BE_REPLACED
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.15.0/3-storage-version-migration-v0.15.0.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/3-storage-version-migration-v0.15.0.yaml
@@ -136,7 +136,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:528cfcb8cc77e091c0a2fb4f379485e76c1efc6bc7cbbbf0293f3577922e5599
+        image: TO_BE_REPLACED
         args:
         - "parallels.flows.knative.dev"
         - "sequences.flows.knative.dev"

--- a/cmd/operator/kodata/knative-eventing/0.15.1/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.1/1-eventing.yaml
@@ -599,7 +599,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:e22a23e05e8344e5126c10737625270db3d32f36da67c6e8b6020fa777723571
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -617,12 +617,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:d6fc16b77a8682dfba7305ac8c19f43e284e565bb7e49a72663e30291ad861e7
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:241b67af3851850d069f320c731c62617182eb8553c12df6ccf359a6ce9f02ee
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:e1026918aa15f2f188bacd49b13355d9dc99c6c5420d8c91500999deb4fae411
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -669,7 +669,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:88c21c79a606e5feb03f43739cece8ab9ea59831af5aa7fe17c07659e2d44342
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.
@@ -3002,7 +3002,7 @@ spec:
       containers:
       - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/channel_broker@sha256:cd2cee6463842c547a14ff0f62806370959b9e16a6fc82409c7781462a06c4bf
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -3020,11 +3020,11 @@ spec:
           value: knative.dev/eventing
         - # Broker
           name: BROKER_INGRESS_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:09e5ea1b066a8dea31de60ed46c323a48dd87323994a48e37c0c2d632e6982f5
+          value: TO_BE_REPLACED
         - name: BROKER_INGRESS_SERVICE_ACCOUNT
           value: eventing-broker-ingress
         - name: BROKER_FILTER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:508a24a308f833f63b55dd8724942be02f1751c15b23ac6eef21af0b0cfe3ca1
+          value: TO_BE_REPLACED
         - name: BROKER_FILTER_SERVICE_ACCOUNT
           value: eventing-broker-filter
         - name: BROKER_IMAGE_PULL_SECRET_NAME
@@ -3319,7 +3319,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:d1280e3194016843d6817540355e4ba415197a55f21de67d8b64bcb535c72452
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3427,7 +3427,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:505575200a6aa053b0773cc566153882a9c31658da6fdd7aa41e26fc4c5f258a
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3536,7 +3536,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:04f3dc50d6b05fbf05685537b60ab0a18eb5f6f1029de0046d03284f3a855128
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -4115,7 +4115,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:5a42c1c71b56eec1d755ee808ebe190df4a82bd03be5fb6682aff6dbbd337189
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -4128,7 +4128,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e7c35b3b1e6ad777661bc5c5361011af42779c7faf917c365ac8af339f51d35e
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -4172,7 +4172,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:e7c35b3b1e6ad777661bc5c5361011af42779c7faf917c365ac8af339f51d35e
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.15.1/2-upgrade-to-v0.15.1.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.1/2-upgrade-to-v0.15.1.yaml
@@ -15,6 +15,6 @@ spec:
       restartPolicy: Never
       containers:
       - name: upgrade-brokers
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/upgrade/v0.15.0@sha256:5322b8b5c1baf725e40734a262997b8e201733feea23e76c5fd532d41e9a8ad8
+        image: TO_BE_REPLACED
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.15.1/3-storage-version-migration-v0.15.1.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.1/3-storage-version-migration-v0.15.1.yaml
@@ -136,7 +136,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:844d6ad010149cdb9a6f82fb4426baebdf1243cb4f14bda001dd479e3c8de497
+        image: TO_BE_REPLACED
         args:
         - "parallels.flows.knative.dev"
         - "sequences.flows.knative.dev"

--- a/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
@@ -599,7 +599,7 @@ spec:
       containers:
       - name: eventing-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:413a3736c4d41b61a547821f1eceeca0786a58cbfa5f4957d2fbb1722df1aa8a
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -617,12 +617,12 @@ spec:
           value: knative.dev/eventing
         - # PingSource
           name: PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:11262100d3861c43fc28b726214f7f0d0358bfccb05b809c619c52c7a7b0ef35
+          value: TO_BE_REPLACED
         - name: MT_PING_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:2b61f9719bedd0d1f23ceaefd9d31689e6c24ec0c7d7f9b0d7171905e2189488
+          value: TO_BE_REPLACED
         - # APIServerSource
           name: APISERVER_RA_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:b77d02b7f6374fdaf2d04875e67e2913fd3bca16ebc1750366508d5f014845d4
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -669,7 +669,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:3d2f3e29f80c39f399f8a4b55e9b00e1db4774212a76eb25ace4c342109cca0b
+        image: TO_BE_REPLACED
         resources:
           requests:
             # taken from serving.
@@ -3001,7 +3001,7 @@ spec:
       containers:
       - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/channel_broker@sha256:a222565cba6fafa1895e79a05809864dba9bae3fa7da803706d1a86541f4af4f
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -3019,11 +3019,11 @@ spec:
           value: knative.dev/eventing
         - # Broker
           name: BROKER_INGRESS_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:825f9176cf27c9fd72a875f7eed6bc8393968731049e8b4ca40f64b0be302682
+          value: TO_BE_REPLACED
         - name: BROKER_INGRESS_SERVICE_ACCOUNT
           value: eventing-broker-ingress
         - name: BROKER_FILTER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:a7abcf0b6bc00723cbb669d8a5366539c2571b666f6103000b6bddf64537dcf4
+          value: TO_BE_REPLACED
         - name: BROKER_FILTER_SERVICE_ACCOUNT
           value: eventing-broker-filter
         - name: BROKER_IMAGE_PULL_SECRET_NAME
@@ -3318,7 +3318,7 @@ spec:
       containers:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:60ee003e24766912c851f14e104f4a7845452c09c6ca5d5defab7b1c2b50b8f3
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3426,7 +3426,7 @@ spec:
       containers:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:5110a0f39a1ae362e5c2c873eba44ed975d55131fc80e31dc7191153951c306c
+        image: TO_BE_REPLACED
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -3535,7 +3535,7 @@ spec:
       containers:
       - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:fc962c8943460d3a13f529f5290cdb7b094d428ab6f31ea99e79597fdfcee274
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -4114,7 +4114,7 @@ spec:
       serviceAccountName: imc-controller
       containers:
       - name: controller
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:54628ec1ff46f684cd2160cae109e98cb8504746ba50019fa6bef522bf1ea913
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -4127,7 +4127,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: DISPATCHER_IMAGE
-          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:594812222e5d2b64881c80f2bf6de5dc9313fbd4e67fb69a2c74ceb1a25e79e4
+          value: TO_BE_REPLACED
         securityContext:
           allowPrivilegeEscalation: false
         ports:
@@ -4171,7 +4171,7 @@ spec:
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher
-        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:594812222e5d2b64881c80f2bf6de5dc9313fbd4e67fb69a2c74ceb1a25e79e4
+        image: TO_BE_REPLACED
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging

--- a/cmd/operator/kodata/knative-eventing/0.15.2/3-storage-version-migration-v0.15.2.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.2/3-storage-version-migration-v0.15.2.yaml
@@ -136,7 +136,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:9ca91a8320d0c705c600264cbfff1883f02ef93e61042e88be3fadd21fc31212
+        image: TO_BE_REPLACED
         args:
         - "parallels.flows.knative.dev"
         - "sequences.flows.knative.dev"

--- a/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
@@ -133,7 +133,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:713bd548700bf7fe5452969611d1cc987051bd607d67a4e7623e140f06c209b2
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -446,7 +446,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:713bd548700bf7fe5452969611d1cc987051bd607d67a4e7623e140f06c209b2
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -1086,7 +1086,7 @@ spec:
       - name: activator
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:a5de0fb75046f2ad29a9394b9f4f31d258c4abaea3529cf3443d69e2aab1a879
+        image: TO_BE_REPLACED
         # The numbers are based on performance test results from
         # https://github.com/knative/serving/issues/1625#issuecomment-511930023
         resources:
@@ -1214,7 +1214,7 @@ spec:
       - name: autoscaler
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:61fc208b9c7923228275f8792288b3e356b2e80432655f237baafcf8ab7c3449
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -1321,7 +1321,7 @@ spec:
       - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:51d92a912852f6bdc62468c7c3932e90786217425421c6b9f5366f4724b39fba
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -1410,7 +1410,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bfb31793e70608a70a8e1c778b6183eba786bcd10491d84807d300accceb46b0
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-serving/0.15.0/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/3-serving-hpa.yaml
@@ -158,7 +158,7 @@ spec:
       - name: autoscaler-hpa
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:807a4ccd295b2ac1a29b5f60b869ff60930d4ebfdc9421b2c041dd17f0c1279c
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m

--- a/cmd/operator/kodata/knative-serving/0.15.0/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/4-net-istio.yaml
@@ -309,7 +309,7 @@ spec:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:270948d92c211fd5f4160a7e0872e9f58ab9c5402152162ab163c0884566a4b7
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -382,7 +382,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:76a2eae18ae029040d36437d13e2a89dc108157104391bd6bf0706d806d2837f
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 20m

--- a/cmd/operator/kodata/knative-serving/0.15.0/5-serving-storage-version-migration.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/5-serving-storage-version-migration.yaml
@@ -34,7 +34,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:9834323fc581b63b505247aa2e590ed4a0b58a225a1d73347a262bb37ad81bc5
+        image: TO_BE_REPLACED
         args:
         - "services.serving.knative.dev"
         - "configurations.serving.knative.dev"

--- a/cmd/operator/kodata/knative-serving/0.15.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.1/2-serving-core.yaml
@@ -133,7 +133,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:c1a48c3b6f17e37dc86d7504eb5382f030fa09050b759c8f62a215f104ff4aef
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -446,7 +446,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:c1a48c3b6f17e37dc86d7504eb5382f030fa09050b759c8f62a215f104ff4aef
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -1086,7 +1086,7 @@ spec:
       - name: activator
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:3d886adfed07bb0cae26dd4bc07e645acd89d36ebb69a4a1cb8a77ce64a49409
+        image: TO_BE_REPLACED
         # The numbers are based on performance test results from
         # https://github.com/knative/serving/issues/1625#issuecomment-511930023
         resources:
@@ -1214,7 +1214,7 @@ spec:
       - name: autoscaler
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:03c88e6ba6e8ba6bf0e50da1521648cbaab8c271423f1249d66d65bc473c6d8a
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -1321,7 +1321,7 @@ spec:
       - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:116f8af8762f0b6a6bb290fcd1585c9ef8795d358a74371d21b431e668d73f98
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -1410,7 +1410,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:d5683da9795caeca467ba6eab1ec9b906e950942d78d794c05fe4c5104bade7f
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-serving/0.15.1/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.1/3-serving-hpa.yaml
@@ -158,7 +158,7 @@ spec:
       - name: autoscaler-hpa
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:b70df07dd272efa423e0a99b013d3c14fd9b1c49658642a1f4c1960358b6bc99
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m

--- a/cmd/operator/kodata/knative-serving/0.15.1/5-serving-storage-version-migration.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.1/5-serving-storage-version-migration.yaml
@@ -34,7 +34,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:2cd1bbcd4e9ec0fc9efd7b636a93cc82631b1d6b5773b486f4d69a7fbec3cf22
+        image: TO_BE_REPLACED
         args:
         - "services.serving.knative.dev"
         - "configurations.serving.knative.dev"

--- a/cmd/operator/kodata/knative-serving/0.15.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.2/2-serving-core.yaml
@@ -133,7 +133,7 @@ metadata:
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:17d7d70396ee04c17fff5d495ef170ecb115ddd4054f00385773c093b63f4f76
+  image: TO_BE_REPLACED
 
 ---
 # Copyright 2018 The Knative Authors
@@ -446,7 +446,7 @@ metadata:
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:17d7d70396ee04c17fff5d495ef170ecb115ddd4054f00385773c093b63f4f76
+  queueSidecarImage: TO_BE_REPLACED
   _example: |
     ################################
     #                              #
@@ -1086,7 +1086,7 @@ spec:
       - name: activator
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:f54d5eaffda684300195ede296011c1aeadbb0ef9db75aef531e90ea24ea529a
+        image: TO_BE_REPLACED
         # The numbers are based on performance test results from
         # https://github.com/knative/serving/issues/1625#issuecomment-511930023
         resources:
@@ -1214,7 +1214,7 @@ spec:
       - name: autoscaler
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:f4956de0736808a57ed8039ec5af1d9cc3ed4ea143b9c736f2f6f56b9bd6b314
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m
@@ -1321,7 +1321,7 @@ spec:
       - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:3aaa4690acdb67c8fa9ca416d66d3d46835e0c123d66fed82ecf800dbecb5dd2
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m
@@ -1410,7 +1410,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:eb595b6ec7ac624a2ecb12c2e71348e69584efc4681565a5f44b0c6dd5092512
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 100m

--- a/cmd/operator/kodata/knative-serving/0.15.2/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.2/3-serving-hpa.yaml
@@ -158,7 +158,7 @@ spec:
       - name: autoscaler-hpa
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:210238a5846ee4b84782111f5cee3a592ea86ad4e36f89241799205f4e8109f9
+        image: TO_BE_REPLACED
         resources:
           requests:
             cpu: 30m

--- a/cmd/operator/kodata/knative-serving/0.15.2/5-serving-storage-version-migration.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.2/5-serving-storage-version-migration.yaml
@@ -36,7 +36,7 @@ spec:
       - name: migrate
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:3f226d9602f5ae74098da93db5152eefa046b7077df2083be78e1b68c8c4cf9b
+        image: TO_BE_REPLACED
         args:
         - "services.serving.knative.dev"
         - "configurations.serving.knative.dev"


### PR DESCRIPTION
Relates to #13 and https://issues.redhat.com/browse/SRVKS-576

"Fixing" this for the 0.15 branch (aka 1.9 Serverless)