### PR TITLE
fix default metrics port

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
@@ -3384,9 +3384,9 @@ spec:
     protocol: TCP
     targetPort: 8080
   - name: http-metrics
-    port: 9090
+    port: 9092
     protocol: TCP
-    targetPort: 9090
+    targetPort: 9092
   selector:
     eventing.knative.dev/brokerRole: filter
 
@@ -3492,9 +3492,9 @@ spec:
     protocol: TCP
     targetPort: 8080
   - name: http-metrics
-    port: 9090
+    port: 9092
     protocol: TCP
-    targetPort: 9090
+    targetPort: 9092
   selector:
     eventing.knative.dev/brokerRole: ingress
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
Fixes https://github.com/openshift-knative/serverless-operator/issues/435
## Proposed Changes

* Updates the http-metrics port in broker-ingress and broker-filter svcs.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/CC @matzew 
Will new deployments get this fix or does it require a new minor release?