### PR TITLE
Move the missing parts for the 'edit' role to the 0.16 - this now matches upstream 0.17+

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
@@ -2173,7 +2173,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     eventing.knative.dev/release: "v0.16.1"
 rules:
-- apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "flows.knative.dev"]
+- apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
   resources: ["*"]
   verbs: ["create", "update", "patch", "delete"]
 ---


### PR DESCRIPTION
more for SRVKE-459

/assign @maschmid 